### PR TITLE
MAJ Frictionless et ajout template PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Vous publiez une nouvelle version d'un schéma ?
+Pensez à réaliser les actions suivantes.
+
+- [ ] Mettre à jour les fichiers d'exemples
+- [ ] Mettre à jour le champ `version`
+- [ ] Mettre à jour le champ `lastModified`
+- [ ] Changer les liens vers les fichiers d'exemples présents dans `schema.json` et `README.md`
+- [ ] Mettre à jour le fichier `CHANGELOG.md` en incluant une description de la version
+- [ ] Merger cette pull-request
+- [ ] Publier un nouveau tag et une nouvelle version
+- [ ] Prévenir les utilisateurs de ce schéma

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-frictionless==4.1
+frictionless==4.26.0


### PR DESCRIPTION
MAJ Frictionless vers 4.26.0 pour vérifier la cohérence des exemples du schéma
ajout template PR